### PR TITLE
Phone number copy-paste, edit customer improved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,8 +94,13 @@ nb-configuration.xml
 ##############################
 .vscode/
 .code-workspace
+target/
+target/classes
+target/test-classes
 
 ##############################
 ## OS X
 ##############################
 *.DS_Store
+*.class
+derby.log

--- a/src/main/java/EditCustomerController.java
+++ b/src/main/java/EditCustomerController.java
@@ -40,6 +40,8 @@ public class EditCustomerController implements Initializable {
      */
     @FXML
     void updateCustomer(ActionEvent event) {
+        Stage window = (Stage) updateCustomerButton.getScene().getWindow();
+
         String firstName = updateCustomerFirstName.getText();
         String lastName = updateCustomerLastName.getText();
         String phone = updateCustomerPhone.getText();
@@ -63,6 +65,7 @@ public class EditCustomerController implements Initializable {
         try
         {
             get = conn.createStatement();
+            update = conn.prepareStatement(sql);
             ResultSet result = get.executeQuery("SELECT * FROM CUSTOMERS");
             while (result.next()) {
                 String testFirstName = result.getString("FIRSTNAME");
@@ -71,11 +74,13 @@ public class EditCustomerController implements Initializable {
                     String testPhone = result.getString("PHONE");
                     String testEmail = result.getString("EMAIL");
                     if (testPhone.equals(phone) && testEmail.equals(email)) {
-                        Alert alert = new Alert(Alert.AlertType.WARNING, "Cannot create duplicate Customers. If two Customers have the exact same name, make sure they have different phones or emails.", ButtonType.OK);
+                        /**Alert alert = new Alert(Alert.AlertType.WARNING, "Cannot create duplicate Customers. If two Customers have the exact same name, make sure they have different phones or emails.", ButtonType.OK);
                         alert.setTitle("Duplicate Customer Entry");
                         alert.setHeaderText("");
                         alert.show();
-                        return;
+                        return;*/
+                        update.close();
+                        window.close();
                     }
                 }
             }
@@ -97,7 +102,7 @@ public class EditCustomerController implements Initializable {
             alert.setHeaderText("");
             alert.show();
         }
-        Stage window = (Stage) updateCustomerButton.getScene().getWindow();
+        
         window.close();
     }
 

--- a/src/main/java/PhoneNumberFilter.java
+++ b/src/main/java/PhoneNumberFilter.java
@@ -16,7 +16,8 @@ public class PhoneNumberFilter implements UnaryOperator<TextFormatter.Change> {
     public TextFormatter.Change apply(TextFormatter.Change change) {
         if (change.isContentChange()) {
             handleBackspaceOverSpecialCharacter(change);
-            if (change.getText().matches("[0-9]*")) {
+            String phoneStr = change.getText().replaceAll("[-() ]*", "");
+            if (phoneStr.matches("[0-9]*")) {
                 int originalNewTextLength = change.getControlNewText().length();
                 change.setText(formatNumber(change.getControlNewText()));
                 change.setRange(0, change.getControlText().length());


### PR DESCRIPTION
Phone numbers can now be copy-pasted with all characters in format 
**(xxx) xxx-xxxx** being ignored properly

Editing a customer and clicking "Save" without making changes no longer has an annoying duplicate entry warning.

Added derby.log to gitignore.